### PR TITLE
Make uhubctl "Yocto-Project Compatible" v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,33 @@
-CFLAGS = -g -O0
-LDFLAGS = -lusb-1.0
+# uhubctl Makefile
+#
+UNAME_S := $(shell uname -s)
+
+DESTDIR ?=
+prefix  ?= /usr
+sbindir ?= $(prefix)/sbin
+
+INSTALL		:= install
+INSTALL_DIR	:= $(INSTALL) -m 755 -d
+INSTALL_PROGRAM	:= $(INSTALL) -m 755
+RM		:= rm -rf
+
+CC ?= gcc
+CFLAGS ?= -g -O0
+
+CFLAGS	+= -Wall -Wextra
+
+ifeq ($(UNAME_S),Linux)
+	LDFLAGS	+= -Wl,-z,relro
+endif
+
 PROGRAM = uhubctl
 
-$(PROGRAM): $(PROGRAM).o
-	cc $(CFLAGS) $@.c -o $@ $(LDFLAGS)
+$(PROGRAM): $(PROGRAM).c
+	$(CC) $(CFLAGS) $@.c -o $@ -lusb-1.0 $(LDFLAGS)
+
+install:
+	$(INSTALL_DIR) $(DESTDIR)$(sbindir)
+	$(INSTALL_PROGRAM) $(PROGRAM) $(DESTDIR)$(sbindir)
 
 clean:
-	rm -rf $(PROGRAM).o $(PROGRAM).dSYM $(PROGRAM)
+	$(RM) $(PROGRAM).o $(PROGRAM).dSYM $(PROGRAM)

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -17,6 +17,7 @@
 #include <getopt.h>
 #include <errno.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #include <libusb-1.0/libusb.h>
 


### PR DESCRIPTION
This pull request makes uhubctl "Yocto-Project Compatible" and therefore adds cross-compile compatibility to the Makefile.

Changes v2:
- set `LDFLAGS` only on Linux based OSes (detect that using `uname`)
- use `-rf` for `RM`