### PR TITLE
compile in with libusb from macports, make Pluggable USB2-HUB-AG7 work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ ifeq ($(UNAME_S),Linux)
 	LDFLAGS	+= -Wl,-z,relro
 endif
 
+ifeq ($(UNAME_S),Darwin)
+	LDFLAGS	+= -L /opt/local/lib -I /opt/local/include
+endif
+
 PROGRAM = uhubctl
 
 $(PROGRAM): $(PROGRAM).c

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -205,7 +205,8 @@ int is_smart_hub(struct libusb_device *dev, int min_current)
             /* Over-Current Protection Mode */
             int ocpm = uhd->wHubCharacteristics[0] & HUB_CHAR_OCPM;
             /* Both LPSM and OCPM must be supported per-port: */
-            if ((lpsm == HUB_CHAR_INDV_PORT_LPSM) &&
+            fprintf(stderr, "DEBUG: %d %d %d %d\n", lpsm, HUB_CHAR_INDV_PORT_LPSM, ocpm, HUB_CHAR_INDV_PORT_OCPM);
+            if ((lpsm == HUB_CHAR_INDV_PORT_LPSM || 1) &&
                 (ocpm == HUB_CHAR_INDV_PORT_OCPM))
             {
                 rc = uhd->bNbrPorts;


### PR DESCRIPTION
On MacOS, with libusb installed from macports, we need some additions to LDPATH. Adding extra directories that don't exist shouldn't be a problem, so testing based on `uname -s` shouldn't break anything for users of `brew`.

Next, to make Pluggable's USB2-HUB-AG7 work, we seem to need to remove the lpsm check in `is_smart_hub()`. I don't have a root cause for this, and this change might cause false positives for other devices or other environments, so comments/improvements are welcome.