### PR TITLE
Add support for compiling under FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ CFLAGS ?= -g -O0
 
 CFLAGS	+= -Wall -Wextra
 
+ifeq ($(UNAME_S),FreeBSD)
+	CFLAGS	+= -lusb
+else
+	LDFLAGS	+= -lusb-1.0
+endif
+
 ifeq ($(UNAME_S),Linux)
 	LDFLAGS	+= -Wl,-z,relro
 endif
@@ -23,7 +29,7 @@ endif
 PROGRAM = uhubctl
 
 $(PROGRAM): $(PROGRAM).c
-	$(CC) $(CFLAGS) $@.c -o $@ -lusb-1.0 $(LDFLAGS)
+	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS)
 
 install:
 	$(INSTALL_DIR) $(DESTDIR)$(sbindir)

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -19,7 +19,11 @@
 #include <ctype.h>
 #include <unistd.h>
 
+#ifdef __FreeBSD__
+#include <libusb.h>
+#else
 #include <libusb-1.0/libusb.h>
+#endif
 
 /* Max number of hub ports supported.
  * This is somewhat artifically limited by "-p" option parser.


### PR DESCRIPTION
This patch adds FreeBSD support by (1) handling libusb differently in the Makefile, and (2) #ifdef wrapping for the #include in the source. It should leave non-FreeBSD environments as they were.