### PR TITLE
Add support for FreeBSD and MacPorts on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,30 @@ RM		:= rm -rf
 
 CC ?= gcc
 CFLAGS ?= -g -O0
-
-CFLAGS	+= -Wall -Wextra
+CFLAGS += -Wall -Wextra
+CFLAGS += -I/usr/include/libusb-1.0
 
 ifeq ($(UNAME_S),Linux)
-	LDFLAGS	+= -Wl,-z,relro
+	LDFLAGS	+= -Wl,-z,relro -lusb-1.0
+endif
+
+ifeq ($(UNAME_S),Darwin)
+ifneq ($(wildcard /opt/local),)
+	# make it work if using MacPorts:
+	CFLAGS	+= -I/opt/local/include/libusb-1.0
+	LDFLAGS	+= -L/opt/local/lib
+endif
+	LDFLAGS	+= -lusb-1.0
+endif
+
+ifeq ($(UNAME_S),FreeBSD)
+	LDFLAGS	+= -lusb
 endif
 
 PROGRAM = uhubctl
 
 $(PROGRAM): $(PROGRAM).c
-	$(CC) $(CFLAGS) $@.c -o $@ -lusb-1.0 $(LDFLAGS)
+	$(CC) $(CFLAGS) $@.c -o $@ $(LDFLAGS)
 
 install:
 	$(INSTALL_DIR) $(DESTDIR)$(sbindir)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Compiling
 =========
 
 This utility was tested to compile and work on Linux
-(Ubuntu, Redhat/Fedora/CentOS) and on Mac OS X.
+(Ubuntu, Redhat/Fedora/CentOS), FreeBSD and on Mac OS X.
 It should be possible to compile it for Windows as well -
 please report if you succeed in doing that.
 
@@ -58,6 +58,7 @@ First, you need to install library libusb-1.0 (version 1.0.12 or later):
 * Ubuntu: sudo apt-get install libusb-1.0-0-dev
 * Redhat: sudo yum install libusb1-devel
 * MacOSX: brew install libusb
+* FreeBSD: libusb is included by default
 * Windows: TBD?
 
 To compile, simply run `make` - this will generate `uhubctl` binary.

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -19,7 +19,7 @@
 #include <ctype.h>
 #include <unistd.h>
 
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
 /* Max number of hub ports supported.
  * This is somewhat artifically limited by "-p" option parser.


### PR DESCRIPTION
Add support for FreeBSD and MacPorts on Mac.
Tested to compile and work on Linux and Mac.
Need to test on FreeBSD.