### PR TITLE
Win32 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+# idea from https://github.com/analogdevicesinc/libsmu/blob/master/appveyor.yml
+os: Visual Studio 2015
+clone_depth: 1
+
+configuration:
+  - Release
+#  - Debug
+
+install:
+  - git clone https://github.com/skandhurkat/Getopt-for-Visual-Studio "C:\projects\Getopt-for-Visual-Studio"
+  - git clone https://github.com/libusb/libusb.git "C:\projects\libusb"
+
+build_script:
+  - ps: pushd "C:\projects\libusb"
+  - msbuild msvc\libusb_2015.sln /p:Platform=Win32 /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - msbuild msvc\libusb_2015.sln /p:Platform=x64 /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - ps: popd
+  - dir
+  - set PATH=%PATH%;C:\MinGW\bin
+  - msbuild uhubctl.vcxproj /p:Platform=Win32 /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - msbuild uhubctl.vcxproj /p:Platform=x64 /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - dir
+  - dir Win32\*
+  - dir x64\*
+
+# https://www.appveyor.com/docs/packaging-artifacts/
+artifacts:
+  - path: Win32/Release/uhubctl.exe
+    name: uhubctl-win32
+    type: zip
+
+  - path: x64/Release/uhubctl.exe
+    name: uhubctl-x64
+    type: zip
+
+# https://www.appveyor.com/docs/deployment/github/
+# deploy:
+  # release: uhubctl-v$(appveyor_build_version)
+  # description: 'uhubctl: new version'
+  # provider: GitHub
+  # auth_token:
+  #  secure: <your encrypted token> # your encrypted token from GitHub
+  # artifact: /.*\.nupkg/            # upload all NuGet packages to release assets
+  # draft: false
+  # prerelease: false
+  # on:
+  #  branch: master                 # release from master branch only
+  # appveyor_repo_tag: true        # deploy on tag push only

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -653,7 +653,7 @@ int main(int argc, char *argv[])
                     }
                 }
                 if (k==0 && opt_action == POWER_CYCLE)
-                    sleep_ms(opt_delay);
+                    sleep_ms(opt_delay * 1000);
                 printf("Sent power %s request\n",
                     request == LIBUSB_REQUEST_CLEAR_FEATURE ? "off" : "on"
                 );

--- a/uhubctl.vcxproj
+++ b/uhubctl.vcxproj
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|Win32">
+			<Configuration>Debug</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|Win32">
+			<Configuration>Release</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<ProjectGuid>{D7BB73A5-0F44-4D2C-BE3C-EF1361621305}</ProjectGuid>
+		<Keyword>Win32Proj</Keyword>
+		<RootNamespace>hubctl</RootNamespace>
+		<WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<UseDebugLibraries>true</UseDebugLibraries>
+		<PlatformToolset>v140</PlatformToolset>
+		<CharacterSet>Unicode</CharacterSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<UseDebugLibraries>false</UseDebugLibraries>
+		<PlatformToolset>v140</PlatformToolset>
+		<WholeProgramOptimization>true</WholeProgramOptimization>
+		<CharacterSet>Unicode</CharacterSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<UseDebugLibraries>true</UseDebugLibraries>
+		<PlatformToolset>v140</PlatformToolset>
+		<CharacterSet>Unicode</CharacterSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<UseDebugLibraries>false</UseDebugLibraries>
+		<PlatformToolset>v140</PlatformToolset>
+		<WholeProgramOptimization>true</WholeProgramOptimization>
+		<CharacterSet>Unicode</CharacterSet>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Label="ExtensionSettings">
+	</ImportGroup>
+	<ImportGroup Label="Shared">
+	</ImportGroup>
+	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+	</ImportGroup>
+	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+	</ImportGroup>
+	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+	</ImportGroup>
+	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+	</ImportGroup>
+	<PropertyGroup Label="UserMacros" />
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<LinkIncremental>true</LinkIncremental>
+		<IncludePath>c:\projects\libusb\libusb;c:\projects\Getopt-for-Visual-Studio;$(IncludePath)</IncludePath>
+		<LibraryPath>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;$(LibraryPath)</LibraryPath>
+		<OutDir>$(SolutionDir)\$(Platform)\$(Configuration)\</OutDir>
+		<IntDir>$(Platform)\$(Configuration)\</IntDir>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<LinkIncremental>true</LinkIncremental>
+		<IncludePath>c:\projects\libusb\libusb;c:\projects\Getopt-for-Visual-Studio;$(IncludePath)</IncludePath>
+		<LibraryPath>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;$(LibraryPath)</LibraryPath>
+		<OutDir>$(SolutionDir)\$(Platform)\$(Configuration)\</OutDir>
+		<IntDir>$(Platform)\$(Configuration)\</IntDir>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<LinkIncremental>false</LinkIncremental>
+		<IncludePath>c:\projects\libusb\libusb;c:\projects\Getopt-for-Visual-Studio;$(IncludePath)</IncludePath>
+		<LibraryPath>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;$(LibraryPath)</LibraryPath>
+		<OutDir>$(SolutionDir)\$(Platform)\$(Configuration)\</OutDir>
+		<IntDir>$(Platform)\$(Configuration)\</IntDir>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<LinkIncremental>false</LinkIncremental>
+		<IncludePath>c:\projects\libusb\libusb;c:\projects\Getopt-for-Visual-Studio;$(IncludePath)</IncludePath>
+		<LibraryPath>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;$(LibraryPath)</LibraryPath>
+		<OutDir>$(SolutionDir)\$(Platform)\$(Configuration)\</OutDir>
+		<IntDir>$(Platform)\$(Configuration)\</IntDir>
+	</PropertyGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<ClCompile>
+			<PrecompiledHeader>
+			</PrecompiledHeader>
+			<WarningLevel>Level3</WarningLevel>
+			<Optimization>Disabled</Optimization>
+			<PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<SDLCheck>true</SDLCheck>
+		</ClCompile>
+		<Link>
+			<SubSystem>Console</SubSystem>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<AdditionalDependencies>libusb-1.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<ClCompile>
+			<PrecompiledHeader>
+			</PrecompiledHeader>
+			<WarningLevel>Level3</WarningLevel>
+			<Optimization>Disabled</Optimization>
+			<PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<SDLCheck>true</SDLCheck>
+		</ClCompile>
+		<Link>
+			<SubSystem>Console</SubSystem>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<AdditionalDependencies>libusb-1.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<ClCompile>
+			<WarningLevel>Level3</WarningLevel>
+			<PrecompiledHeader>
+			</PrecompiledHeader>
+			<Optimization>MaxSpeed</Optimization>
+			<FunctionLevelLinking>true</FunctionLevelLinking>
+			<IntrinsicFunctions>true</IntrinsicFunctions>
+			<PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<SDLCheck>true</SDLCheck>
+		</ClCompile>
+		<Link>
+			<SubSystem>Console</SubSystem>
+			<EnableCOMDATFolding>true</EnableCOMDATFolding>
+			<OptimizeReferences>true</OptimizeReferences>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<AdditionalDependencies>libusb-1.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<ClCompile>
+			<WarningLevel>Level3</WarningLevel>
+			<PrecompiledHeader>
+			</PrecompiledHeader>
+			<Optimization>MaxSpeed</Optimization>
+			<FunctionLevelLinking>true</FunctionLevelLinking>
+			<IntrinsicFunctions>true</IntrinsicFunctions>
+			<PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<SDLCheck>true</SDLCheck>
+		</ClCompile>
+		<Link>
+			<SubSystem>Console</SubSystem>
+			<EnableCOMDATFolding>true</EnableCOMDATFolding>
+			<OptimizeReferences>true</OptimizeReferences>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<AdditionalDependencies>libusb-1.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>c:\projects\libusb\$(PlatformName)\$(ConfigurationName)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ClCompile Include="uhubctl.c" />
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+	<ImportGroup Label="ExtensionTargets">
+	</ImportGroup>
+</Project>


### PR DESCRIPTION
Hi!

I've added the windows build with AppVeyor. C code now builds with VS2015, but little hairy.

Code builds with latest git version of libusb and this can be a problem, but you can easily add tag checkout. I would add the revision checkout, If not an issues with [windows hotplug](https://github.com/libusb/libusb/issues/86).

For each build you can download [binary executables](https://ci.appveyor.com/project/apla/uhubctl/build/1.0.12/artifacts)

Also it is possible to upload builds to github releases. I've added configuration template [as per docs](https://www.appveyor.com/docs/deployment/github/), but you should provide github key yourself.

I don't have smart hub at hand, so I cannot check whether port switch works or not, but device enumeration works ok.
