### PR TITLE
Fix port status power check for USB 3.0 hub

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -746,15 +746,33 @@ int main(int argc, char *argv[])
                 for (port=1; port <= hubs[i].nports; port++) {
                     if ((1 << (port-1)) & ports) {
                         int port_status = get_port_status(devh, port);
-                        if (k == 0 && !(port_status & USB_PORT_STAT_POWER))
-                            continue;
-                        if (k == 1 && (port_status & USB_PORT_STAT_POWER))
-                            continue;
+                        if(hubs[i].bcd_usb < 0x300 )
+                        {
+                            if (k == 0 && !(port_status & USB_PORT_STAT_POWER))
+                                continue;
+                            if (k == 1 && (port_status & USB_PORT_STAT_POWER))
+                                continue;
+                        }
+                        else
+                        {
+                            if (k == 0 && !(port_status & USB_SS_PORT_STAT_POWER))
+                                continue;
+                            if (k == 1 && (port_status & USB_SS_PORT_STAT_POWER))
+                                continue;
+                        }
                         int repeat = 1;
                         if (k == 0)
                             repeat = opt_repeat;
-                        if (!(port_status & ~USB_PORT_STAT_POWER))
-                            repeat = 1;
+                        if(hubs[i].bcd_usb < 0x300 )
+                        {
+                            if (!(port_status & ~USB_PORT_STAT_POWER))
+                                repeat = 1;
+                        }
+                        else
+                        {
+                            if (!(port_status & ~USB_SS_PORT_STAT_POWER))
+                                repeat = 1;
+                        }
                         while (repeat-- > 0) {
                             rc = libusb_control_transfer(devh,
                                 LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_OTHER,


### PR DESCRIPTION
The port status bits are different for USB 3.0 hub.
USB 3.0 hub needs to have both USB 2.0 and USB 3.0 port disable for the power to be removed, depending on model.

Tested on Amazon Basic USB 3.0 Hub.