### PR TITLE
Allow specifying milliseconds for the delay.

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -962,7 +962,7 @@ int main(int argc, char *argv[])
             libusb_close(devh);
         }
         if (k == 0 && opt_action == POWER_CYCLE)
-            sleep_ms(opt_delay * 1000);
+            sleep_ms(opt_delay);
     }
     rc = 0;
 cleanup:


### PR DESCRIPTION
As discussed on ntimeu/uhubctl@a62e74f5c5e5399be98a54c3d1e758e00532ea6d and updated by 75b97f11c9c246eccfc8abaee85cc614befe1252, allow the use of float for the delay option, allowing users to specify the delay in milliseconds.

PR is backward-compatible with previous versions (specifying int will not change behavior).

Tested on Raspberry PI 3B+.