### PR TITLE
Add fallback version if git fails during make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ RM		:= rm -rf
 CC ?= gcc
 CFLAGS ?= -g -O0
 CFLAGS += -Wall -Wextra -std=c99 -pedantic
-GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+GIT_VERSION := \
+    $(shell git describe --abbrev=4 --dirty --always --tags || \
+        (echo 'Using fallback version "DEV"!' 1>&2 && echo 'DEV'))
 CFLAGS += -DPROGRAM_VERSION=\"$(GIT_VERSION)\"
 
 ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
Fixes #100.

Build uses the git tag for uhubctl version; building in a non-git repo
(eg from a bare archive downloaded from github) causes a failure to
retrieve the version number, though the build still succeeds; it just
has a blank version.

Add a fallback 'DEV' version string to be inserted if the git describe
shell command fails.