### PR TITLE
add a level hub filter

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -710,6 +710,9 @@ static int usb_find_hubs()
                 if (hubs[i].nports != hubs[j].nports)
                     continue;
 
+                if (hubs[i].level != hubs[j].level)
+                    continue;
+
                 /* If description is the same, provisionally we choose this one as dual.
                  * If description contained serial number, this will be most reliable matching.
                  */

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -661,8 +661,8 @@ static int usb_find_hubs()
                         info.actionable = 0;
                     }
                 }
-                if (opt_level != -1){
-                    if (opt_level != info.level){
+                if (opt_level != -1) {
+                    if (opt_level != info.level) {
                         info.actionable = 0;
                     }
                 }

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -236,7 +236,7 @@ static int print_usage()
         "--action,   -a - action to off/on/cycle (0/1/2) for affected ports.\n"
         "--ports,    -p - ports to operate on    [all hub ports].\n"
         "--loc,      -l - limit hub by location  [all smart hubs].\n"
-        "--level     -L - limit hub by level     [all smart hubs].\n"
+        "--level     -L - limit hub by location level [%d] (e.g. a.b-c is level 3) \n"
         "--vendor,   -n - limit hub by vendor id [%s] (partial ok).\n"
         "--delay,    -d - delay for cycle action [%g sec].\n"
         "--repeat,   -r - repeat power off count [%d] (some devices need it to turn off).\n"

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -236,7 +236,7 @@ static int print_usage()
         "--action,   -a - action to off/on/cycle (0/1/2) for affected ports.\n"
         "--ports,    -p - ports to operate on    [all hub ports].\n"
         "--loc,      -l - limit hub by location  [all smart hubs].\n"
-        "--level     -L - limit hub by location level [%d] (e.g. a.b-c is level 3) \n"
+        "--level     -L - limit hub by location level (e.g. a.b-c is level 3) \n"
         "--vendor,   -n - limit hub by vendor id [%s] (partial ok).\n"
         "--delay,    -d - delay for cycle action [%g sec].\n"
         "--repeat,   -r - repeat power off count [%d] (some devices need it to turn off).\n"

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -710,6 +710,7 @@ static int usb_find_hubs()
                 if (hubs[i].nports != hubs[j].nports)
                     continue;
 
+                /* And the same level: */
                 if (hubs[i].level != hubs[j].level)
                     continue;
 

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -199,7 +199,7 @@ static int hub_phys_count = 0;
 /* default options */
 static char opt_vendor[16]   = "";
 static char opt_location[32] = "";     /* Hub location a-b.c.d */
-static int opt_level = -1;
+static int opt_level = 0;              /* Hub location level (e.g., a-b is level 2, a-b.c is level 3)*/
 static int opt_ports  = ALL_HUB_PORTS; /* Bitmask of ports to operate on */
 static int opt_action = POWER_KEEP;
 static double opt_delay = 2;
@@ -661,7 +661,7 @@ static int usb_find_hubs()
                         info.actionable = 0;
                     }
                 }
-                if (opt_level != -1) {
+                if (opt_level != 0) {
                     if (opt_level != info.level) {
                         info.actionable = 0;
                     }


### PR DESCRIPTION
Thank you for your excellent work. This program is very helpful.

Scenario:
In my usage, I have two identical hubs. 
host -> hub1 -> hub2 -> device

I want to control the port of the second hub, while I don't care which port of the first hub was used.

In this usage, I need to use a script to find the port and create the -l part. With the change, It is as easy as
```uhubctl -L 3```

Also, I think this level info is helpful for the dual match. I'm using nvidia TX2, which 
the usb3 port is assigned as 1-2
and the usb2 port is 2-1

The program was confused between the two hubs.



