### PR TITLE
Fix compile warning about format truncation by increasing buffer size

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -182,7 +182,7 @@ struct descriptor_strings {
     char vendor[64];
     char product[64];
     char serial[64];
-    char description[256];
+    char description[512];
 };
 
 struct hub_info {


### PR DESCRIPTION
```
$ make
cc  -g -O0 -Wall -Wextra -std=c99 -pedantic -DPROGRAM_VERSION=\"v2.1.0-11-g39b407a8\" uhubctl.c -o uhubctl -Wl,-zrelro,-znow -lusb-1.0
uhubctl.c: In function ‘get_device_description’:
uhubctl.c:543:31: warning: ‘%s’ directive output may be truncated writing up to 63 bytes into a region of size between 58 and 247 [-Wformat-truncation=]
         "%04x:%04x%s%s%s%s%s%s%s",
                               ^~
uhubctl.c:548:9:
         ports
         ~~~~~                  
uhubctl.c:542:5: note: ‘snprintf’ output 10 or more bytes (assuming 262) into a destination of size 256
     snprintf(ds->description, sizeof(ds->description),
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         "%04x:%04x%s%s%s%s%s%s%s",
         ~~~~~~~~~~~~~~~~~~~~~~~~~~
         id_vendor, id_product,
         ~~~~~~~~~~~~~~~~~~~~~~
         ds->vendor[0]  ? " " : "", ds->vendor,
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ds->product[0] ? " " : "", ds->product,
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ds->serial[0]  ? " " : "", ds->serial,
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ports
         ~~~~~
     );
     ~
```