### PR TITLE
Update license hash to correct value, fixing yocto building

### DIFF
--- a/uhubctl_git.bb
+++ b/uhubctl_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "uhubctl - USB hub per-port power control"
 HOMEPAGE = "https://github.com/mvp/uhubctl"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
-                    file://LICENSE;md5=7a7d8e0fdffe495ff61f52ceee61b2f7"
+                    file://LICENSE;md5=8da8e297bccbdbf1006187c1285184a3"
 
 DEPENDS = "libusb1"
 RDEPENDS_${PN} = "libusb1"


### PR DESCRIPTION
The license copyright year was updated but the yocto/bitbake recipe was not updated.  This commit brings them both in sync, just in time for 2020.  :-)