### PR TITLE
README.md - added Belkin F5U404 (incompatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ do support this feature - you may not even need to buy any external hub.
 so be careful what ports you are turning off!
 
 
+Incompatible USB hubs
+=====================
+
+This is list of known *incompatible* USB hubs:
+
+| Manufacturer       | Product                                              | Ports | USB | VID:PID   | Release | EOL  |
+|:-------------------|:-----------------------------------------------------|:------|:----|:----------|:--------|:-----|
+| Belkin             | F5U404                                               | 4     | 2.0 |`0A5C:4500`| 2010    |      |
+
+
 USB 3.0 duality note
 ====================
 If you have USB 3.0 hub connected to USB3 upstream port, it will be detected


### PR DESCRIPTION
It might be helpful to have an **Incompatible Hubs** section. I'm not sure how extensive the list is likely to be, though, so I'll understand if you prefer *not* to merge this pull request!

I bought this Belkin hub and when I run `sudo uhubctl` it says `No compatible smart hubs detected!` Thankfully, the hub does exactly what I need already - it powers-down automatically when the host computer goes to sleep. So in the end I didn't need `uhubctl`! But it's great tool when used with compatible hubs. 😃 