### PR TITLE
Compare hub location to solve incorrect matching of USB2 and USB3 hubs

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -773,6 +773,18 @@ static int usb_find_hubs()
                 if (hubs[i].nports != hubs[j].nports)
                     continue;
 
+                /* Hubs should have the same location except for the bus number: */
+                char * ports_i = strchr(hubs[i].location,'-');
+                char * ports_j = strchr(hubs[j].location,'-');
+                if ((ports_i != NULL) && (ports_j != NULL))
+                {
+                    if ((strlen(ports_i + 1) > 0 && strlen(ports_j + 1) > 0) &&
+                        strcmp(ports_i + 1, ports_j + 1) != 0)
+                    {
+                        continue;
+                    }
+                }
+
                 /* Finally, we claim a match: */
                 match = j;
                 break;


### PR DESCRIPTION
This PR should fix #248 . At least it works well for the Amazon Basics 10 port hub HU9002V1ESL.

It's based on the assumption that if there are several USB3 hubs in a certain device (e.g. `4-2`, `4-2.4`, `4-2.4.4`) and several USB2 hubs (e.g. `3-2`,  `3-2.4`, `3-2.4.4`), then the USB2-USB3 correspondence should be based in the part of the location that is after the dash `-`.

I'm not sure if this assumption is correct for any device, but it seems to be for the HU9002V1ESL.