### PR TITLE
Add Waveshare USB-HUB-3U-ETH hub to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ This is list of known compatible USB hubs:
 | Targus             | PAUH212/PAUH212U                                     | 7     | 2.0 |           | 2004    | 2009 |
 | Texas Instruments  | TUSB4041PAPEVM                                       | 4     | 2.1 |`0451:8142`| 2015    |      |
 | UUGear             | MEGA4 (for Raspberry Pi 4B)                          | 4     | 3.0 |`2109:0817`| 2021    |      |
+| Waveshare          | USB-HUB-3U-ETH (Ganged configuration)                | 3     | 2.0 |`1A40:0101`| 2023    |      |
 
 This table is by no means complete.
 If your hub works with `uhubctl`, but is not listed above, please report it


### PR DESCRIPTION
Tested with the following arguments:

```
$ uhubctl -f -l 3-4 -a 1
Current status for hub 3-4 [1a40:0101 USB 2.0 Hub, USB 2.00, 4 ports, ganged]
  Port 1: 0000 off
  Port 2: 0000 off
  Port 3: 0000 off
  Port 4: 0000 off
Sent power on request
New status for hub 3-4 [1a40:0101 USB 2.0 Hub, USB 2.00, 4 ports, ganged]
  Port 1: 0101 power connect []
  Port 2: 0100 power
  Port 3: 0100 power
  Port 4: 0101 power connect []

$ uhubctl -f -l 3-4
Current status for hub 3-4 [1a40:0101 USB 2.0 Hub, USB 2.00, 4 ports, ganged]
  Port 1: 0103 power enable connect [0a5c:2763 Broadcom BCM2708 Boot]
  Port 2: 0100 power
  Port 3: 0100 power
  Port 4: 0503 power highspeed enable connect [0bda:8152 Realtek USB 10/100 LAN 00E04C360150]

$ uhubctl -f -l 3-4 -a 0
Current status for hub 3-4 [1a40:0101 USB 2.0 Hub, USB 2.00, 4 ports, ganged]
  Port 1: 0103 power enable connect [0a5c:2763 Broadcom BCM2708 Boot]
  Port 2: 0100 power
  Port 3: 0100 power
  Port 4: 0503 power highspeed enable connect [0bda:8152 Realtek USB 10/100 LAN 00E04C360150]
Sent power off request
New status for hub 3-4 [1a40:0101 USB 2.0 Hub, USB 2.00, 4 ports, ganged]
  Port 1: 0000 off
  Port 2: 0000 off
  Port 3: 0000 off
  Port 4: 0000 off

$ uhubctl -f -l 3-4
Current status for hub 3-4 [1a40:0101 USB 2.0 Hub, USB 2.00, 4 ports, ganged]
  Port 1: 0000 off
  Port 2: 0000 off
  Port 3: 0000 off
  Port 4: 0000 off
```

Note: this hub has ports ganged together, so requires the `--force` option