### PR TITLE
List hubs with "ganged" configuration without --force

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -844,7 +844,7 @@ static int usb_find_hubs(void)
             continue;
         }
         get_device_description(dev, &info.ds);
-        if (info.lpsm != HUB_CHAR_INDV_PORT_LPSM && !opt_force) {
+        if (info.lpsm == HUB_CHAR_NO_LPSM && !opt_force) {
             continue;
         }
         info.actionable = 1;


### PR DESCRIPTION
Prior to this commit, uhubctl does not show hubs with a "ganged" or "common" power configuration (HUB_CHAR_COMMON_LPSM) unless the --force argument is passed in.

With this change, hubs are shown if they support either HUB_CHAR_COMMON_LPSM or HUB_CHAR_INDV_PORT_LPSM.