### PR TITLE
Add labgrid to README as project using uhubctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ Notable projects using uhubctl
 | [Do it yourself PPPS](https://git.io/J3lHs)              | Solder wires in your USB hub to support uhubctl         |
 | [Open source PPPS hub](https://tinyurl.com/yckhystt)     | Open source hardware project for uhubctl compatible hub |
 | [Python Wrapper for uhubctl](https://github.com/nbuchwitz/python3-uhubctl) | Module to use uhubctl with Python     |
+| [labgrid](https://github.com/labgrid-project/labgrid)    | Framework for testing embedded Linux on hardware        |
 
 
 Copyright


### PR DESCRIPTION
labgrid uses uhubctl in the USBPowerDriver to control power for boards connected on switchable USB hubs [1].

[1] https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/powerdriver.py