### PR TITLE
Add flipoff (inverted cycle) option - turn on and off

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -80,7 +80,7 @@ void sleep_ms(int milliseconds)
 #define POWER_ON                 1
 #define POWER_CYCLE              2
 #define POWER_TOGGLE             3
-#define POWER_FLIPOFF            4
+#define POWER_FLASH              4
 
 #define MAX_HUB_CHAIN            8  /* Per USB 3.0 spec max hub chain is 7 */
 
@@ -270,13 +270,13 @@ static int print_usage(void)
         "Without options, show status for all smart hubs.\n"
         "\n"
         "Options [defaults in brackets]:\n"
-        "--action,   -a - action to off/on/cycle/toggle/flopoff (0/1/2/3/4) for affected ports.\n"
+        "--action,   -a - action to off/on/cycle/toggle/flash (0/1/2/3/4) for affected ports.\n"
         "--ports,    -p - ports to operate on    [all hub ports].\n"
         "--location, -l - limit hub by location  [all smart hubs].\n"
         "--level     -L - limit hub by location level (e.g. a-b.c is level 3).\n"
         "--vendor,   -n - limit hub by vendor id [%s] (partial ok).\n"
         "--search,   -s - limit hub by attached device description.\n"
-        "--delay,    -d - delay for cycle/flipoff action [%g sec].\n"
+        "--delay,    -d - delay for cycle/flash action [%g sec].\n"
         "--repeat,   -r - repeat power off count [%d] (some devices need it to turn off).\n"
         "--exact,    -e - exact location (no USB3 duality handling).\n"
         "--force,    -f - force operation even on unsupported hubs.\n"
@@ -1113,8 +1113,8 @@ int main(int argc, char *argv[])
             if (!strcasecmp(optarg, "toggle") || !strcasecmp(optarg, "3")) {
                 opt_action = POWER_TOGGLE;
             }
-            if (!strcasecmp(optarg, "flipoff") || !strcasecmp(optarg, "4")) {
-                opt_action = POWER_FLIPOFF;
+            if (!strcasecmp(optarg, "flash") || !strcasecmp(optarg, "4")) {
+                opt_action = POWER_FLASH;
             }
             break;
         case 'd':
@@ -1230,7 +1230,10 @@ int main(int argc, char *argv[])
             if (rc == 0) {
                 /* will operate on these ports */
                 int ports = ((1 << hubs[i].nports) - 1) & opt_ports;
-                int should_be_on = opt_action != POWER_FLIPOFF ? k : !k;
+                int should_be_on = k;
+                if (opt_action == POWER_FLASH) {
+                    k = !k;
+                }
 
                 int port;
                 for (port=1; port <= hubs[i].nports; port++) {
@@ -1270,7 +1273,7 @@ int main(int argc, char *argv[])
             }
             libusb_close(devh);
         }
-        if (k == 0 && (opt_action == POWER_CYCLE || opt_action == POWER_FLIPOFF))
+        if (k == 0 && (opt_action == POWER_CYCLE || opt_action == POWER_FLASH))
             sleep_ms((int)(opt_delay * 1000));
     }
     rc = 0;


### PR DESCRIPTION
I need a feature to turn the specified port on and off after a specific delay,

The example below is to turn the port #1 at location 1-1.4 on and to turn it off after 1.5 second delay

```bash
uhubctl -d 1.5 -a flipoff -l 1-1.4 -p 1
```