### PR TITLE
Add --sysdev/-y option for direct device node access

### DIFF
--- a/uhubctl.c
+++ b/uhubctl.c
@@ -1250,9 +1250,9 @@ int main(int argc, char *argv[])
             rc = 1;
             goto cleanup;
         }
-	dev_list[0] = libusb_get_device(sys_devh);
-	dev_list[1] = NULL;
-	usb_devs = dev_list;
+        dev_list[0] = libusb_get_device(sys_devh);
+        dev_list[1] = NULL;
+        usb_devs = dev_list;
     } else {
         rc = libusb_get_device_list(NULL, &usb_devs);
     }

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -236,7 +236,7 @@ static const char short_options[] =
     "l:L:n:a:p:d:r:w:s:hvefRN"
 #if defined(__gnu_linux__) || defined(__linux__)
 #if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000107)
-    "Su:"
+    "Sy:"
 #else
     "S"
 #endif
@@ -259,7 +259,7 @@ static const struct option long_options[] = {
 #if defined(__gnu_linux__) || defined(__linux__)
     { "nosysfs",  no_argument,       NULL, 'S' },
 #if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000107)
-    { "sysdev",   required_argument, NULL, 'u' },
+    { "sysdev",   required_argument, NULL, 'y' },
 #endif
 #endif
     { "reset",    no_argument,       NULL, 'R' },
@@ -291,7 +291,7 @@ static int print_usage(void)
 #if defined(__gnu_linux__) || defined(__linux__)
         "--nosysfs,  -S - do not use the Linux sysfs port disable interface.\n"
 #if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000107)
-        "--sysdev,   -u - open system device node instead of scanning.\n"
+        "--sysdev,   -y - open system device node instead of scanning.\n"
 #endif
 #endif
         "--reset,    -R - reset hub after each power-on action, causing all devices to reassociate.\n"
@@ -1187,7 +1187,7 @@ int main(int argc, char *argv[])
             opt_nosysfs = 1;
             break;
 #if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000107)
-        case 'u':
+        case 'y':
             opt_sysdev = optarg;
             break;
 #endif

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -1116,7 +1116,6 @@ int main(int argc, char *argv[])
   (defined(__gnu_linux__) || defined(__linux__))
     int sys_fd;
     libusb_device_handle *sys_devh = NULL;
-    libusb_device *dev_list[2];
 #endif
 
     for (;;) {
@@ -1250,9 +1249,13 @@ int main(int argc, char *argv[])
             rc = 1;
             goto cleanup;
         }
-        dev_list[0] = libusb_get_device(sys_devh);
-        dev_list[1] = NULL;
-        usb_devs = dev_list;
+        usb_devs = calloc(2, sizeof *usb_devs);
+        if (!usb_devs) {
+            fprintf(stderr, "Out of memory\n");
+            rc = 1;
+            goto cleanup;
+        }
+        usb_devs[0] = libusb_get_device(sys_devh);
     } else {
         rc = libusb_get_device_list(NULL, &usb_devs);
     }
@@ -1370,6 +1373,7 @@ cleanup:
         if (sys_devh)
             libusb_close(sys_devh);
         close(sys_fd);
+        free(usb_devs);
     } else if (usb_devs)
         libusb_free_device_list(usb_devs, 1);
 #else

--- a/uhubctl.c
+++ b/uhubctl.c
@@ -1244,7 +1244,9 @@ int main(int argc, char *argv[])
         }
         rc = libusb_wrap_sys_device(NULL, sys_fd, &sys_devh);
         if (rc != 0) {
-            fprintf(stderr, "Cannot wrap system node!\n");
+            fprintf(stderr,
+                    "Cannot use %s as USB hub device, failed to wrap system node!\n",
+                    opt_sysdev);
             rc = 1;
             goto cleanup;
         }


### PR DESCRIPTION
Only the device specified by the given device path will be accessed, instead of scanning the USB bus.

Most useful if you use udev rules to create stable device node aliases for hubs, independent of bus topology.

For instance, if your matching udev rules include `SYMLINK+="MYSMARTHUB1"` you can call uhubctl with `--sysdev /dev/MYSMARTHUB1` instead of using `-l` and a non-stable bus location to specify it.