### PR TITLE
Add note to ReTRY HUB

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is list of known compatible USB hubs:
 | BenQ               | PD2700U 4K Monitor (works only in USB2 mode)         | 4     | 3.0 |`05E3:0610`| 2018    |      |
 | BenQ               | PD3220U                                              | 4     | 3.1 |`05E3:0610`| 2019    |      |
 | Bytecc             | BT-UH340 ([warning](https://tinyurl.com/BT-UH340-1)) | 4     | 3.0 |`2109:8110`| 2010    |      |
-| Centech            | CT-USB4HUB ReTRY HUB                                 | 4     | 3.0 |`0424:2744`| 2017    |      |
+| Centech            | CT-USB4HUB ReTRY HUB ([note](https://github.com/mvp/uhubctl/issues/630)) | 4     | 3.0 |`0424:2744`| 2017    |      |
 | Circuitco          | Beagleboard-xM (internal USB hub)                    | 4     | 2.0 |`0424:9514`| 2010    |      |
 | Club3D             | CSV-3242HD Dual Display Docking Station              | 4     | 3.0 |`2109:2811`| 2015    |      |
 | Coolgear           | USBG-12U2ML                                          | 12    | 2.0 |`05e3:0607`| 2015    |      |


### PR DESCRIPTION
As I wrote in https://github.com/mvp/uhubctl/issues/630, the current version of ReTRY HUB may have a problem.
Although the current list of the compatible hubs is not wrong because it just talks about the previous version of ReTRY HUB, I want to add a note about the current version in order to prevent confusion.