### PR TITLE
README.md: Add usbhubctl  and Octoprobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,8 @@ Notable projects using uhubctl
 | [Python Wrapper for uhubctl](https://github.com/nbuchwitz/python3-uhubctl) | Module to use uhubctl with Python     |
 | [labgrid](https://github.com/labgrid-project/labgrid)    | Framework for testing embedded Linux on hardware        |
 | [Thermal Camera](https://tinyurl.com/5asne8hw)           | Turn on/off robot's thermal camera when necessary       |
-
+| [Usbhubctl](https://github.com/octoprobe/usbhubctl)      | Pure python version of uhubctl. Autodetect komplex hubs |
+| [Octoprobe](https://github.com/octoprobe/tentacle)       | Hardware with per port power control. KiCad/USB2514B    |
 
 Copyright
 =========

--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Notable projects using uhubctl
 | [Python Wrapper for uhubctl](https://github.com/nbuchwitz/python3-uhubctl) | Module to use uhubctl with Python     |
 | [labgrid](https://github.com/labgrid-project/labgrid)    | Framework for testing embedded Linux on hardware        |
 | [Thermal Camera](https://tinyurl.com/5asne8hw)           | Turn on/off robot's thermal camera when necessary       |
+| [Usb2_hub](https://github.com/brainsmoke/usb2_hub)       | Hardware with per port power control. KiCad/FE1.1       |
 | [Usbhubctl](https://github.com/octoprobe/usbhubctl)      | Pure python version of uhubctl. Autodetect komplex hubs |
 | [Octoprobe](https://github.com/octoprobe/tentacle)       | Hardware with per port power control. KiCad/USB2514B    |
 


### PR DESCRIPTION
I added two of my projects to README.md. Both projects do not directly use uhubctl as they are pure python. But they are inspired from uhubctl and strongly related.