### PR TITLE
Add LEINSIS 10-Port USB 3.2 Hub to supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This is list of known compatible USB hubs:
 | Lenovo             | ThinkPlus 4-in-1 USB-C hub 4X90W86497                | 3     | 3.0 |           | 2021    |      |
 | Lenovo             | ThinkVision T24i-10 Monitor                          | 4     | 2.0 |`17EF:0610`| 2018    |      |
 | Lenovo             | USB-C to 4 Port USB-A Hub ([USB2 only](https://github.com/mvp/uhubctl/issues/625)) | 4     | 2.0 |`17EF:103A`| 2020    |      |
+| LEINSIS            | [10-Port USB 3.2 Hub](https://www.amazon.com/dp/B0C84G7YJY) | 4     | 3.2 |`05E3:0625`| 2023    |      |
 | Lindy              | USB serial converter 4 port                          | 4     | 1.1 |`058F:9254`| 2008    |      |
 | Linksys            | USB2HUB4 ([note](https://git.io/JYiDZ))              | 4     | 2.0 |           | 2004    | 2010 |
 | Maplin             | A08CQ ([red ports only](https://tinyurl.com/gh635))  | 7     | 2.0 |`0409:0059`| 2008    | 2011 |


### PR DESCRIPTION
## Summary
- Adds LEINSIS 10-Port USB 3.2 Hub to the compatible devices table
- VID:PID `05E3:0625` (Genesys Logic USB 3.2 Hub chip)
- Product link: https://www.amazon.com/dp/B0C84G7YJY

## Test Results

Tested on Linux (Ubuntu) with uhubctl 2.5.0:

```
Current status for hub 6-1.2 [05e3:0625 GenesysLogic USB3.2 Hub, USB 3.20, 4 ports, ppps]
  Port 1: 02a0 power 5gbps Rx.Detect
  Port 2: 02a0 power 5gbps Rx.Detect
  Port 3: 02a0 power 5gbps Rx.Detect
  Port 4: 0263 power 5gbps U3 enable connect
```

**VBUS off test:** Confirmed that power is actually cut off when port is disabled (USB storage device disconnects completely, not just data).

```
# Power off
$ sudo uhubctl -l 1-4.2 -p 3 -a off
Current status for hub 1-4.2 [05e3:0610 GenesysLogic USB2.1 Hub, USB 2.10, 4 ports, ppps]
  Port 3: 0503 power highspeed enable connect [0930:6545 USB Flash Memory]
Sent power off request
New status for hub 1-4.2 [05e3:0610 GenesysLogic USB2.1 Hub, USB 2.10, 4 ports, ppps]
  Port 3: 0000 off

# Power on
$ sudo uhubctl -l 1-4.2 -p 3 -a on
New status for hub 1-4.2 [05e3:0610 GenesysLogic USB2.1 Hub, USB 2.10, 4 ports, ppps]
  Port 3: 0101 power connect
```

Device successfully re-enumerated after power restore.