### PR TITLE
Add Satechi Mac Mini Hub (M1/M2) to supported hardware list

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ This is list of known compatible USB hubs:
 | Rosonway           | RSH-ST07C ([only 4](https://tinyurl.com/4pjnujrn))   | 7     | 3.0 |`2109:2822`| 2023    |      |
 | Rosonway           | RSH-ST10C-6 ([note](https://tinyurl.com/428vpa2f))   | 10    | 3.1 |           | 2024    |      |
 | Sanwa Supply       | USB-HUB14GPH                                         | 4     | 1.1 |           | 2001    | 2003 |
+| Satechi            | Mac Mini Hub (M1/M2)                                 | 4     | 3.0 |`2109:2817`| 2023    |      |
 | Seagate            | Backup Plus Hub STEL8000100                          | 2     | 3.0 |`0BC2:AB44`| 2016    |      |
 | Seeed Studio       | reTerminal CM4104032                                 | 2     | 2.0 |`0424:2514`| 2021    |      |
 | Sipolar            | A-173                                                | 7     | 3.0 |`0BDA:0411`| 2016    |      |


### PR DESCRIPTION
## Summary

- Adds the Satechi Mac Mini Hub (M1/M2) to the supported hardware list
- 4-port USB 3.0 hub with vendor:product ID `2109:2817`, released in 2023
- Inserted alphabetically between Sanwa Supply and Seagate entries

## Product

[Amazon Link](https://www.amazon.com/dp/B0CR1WWSGN)

## Test plan

- [x] Verify `uhubctl` detects the hub with `2109:2817` on macOS (M1/M2 Mac Mini)
- [ ] Confirm per-port power switching works on all 4 USB 3.0 ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)