### PR TITLE
Add Dell DA300 as compatible device

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This is list of known compatible USB hubs:
 | D-Link             | DUB-H4 rev D,E (black). Note: rev A,C,F not supported| 4     | 2.0 |`05E3:0608`| 2012    |      |
 | D-Link             | DUB-H7 rev A (silver)                                | 7     | 2.0 |`2001:F103`| 2005    | 2010 |
 | D-Link             | DUB-H7 rev D,E (black). Rev B,C,F,G not supported    | 7     | 2.0 |`05E3:0608`| 2012    |      |
+| Dell               | DA300 USB-C Mobile Adapter                           | 2     | 3.0 |`2109:2820`| 2018    |      |
 | Dell               | P2416D 24" QHD Monitor ([note](https://git.io/JUAu8))| 4     | 2.0 |           | 2017    |      |
 | Dell               | S2719DGF 27" WQHD Gaming-Monitor                     | 5     | 3.0 |`0424:5734`| 2018    |      |
 | Dell               | UltraSharp 1704FPT 17" LCD Monitor                   | 4     | 2.0 |`0424:A700`| 2005    | 2015 |


### PR DESCRIPTION
The DA300 exposes multiple internal USB nodes (MCU, Gigabit Ethernet, video output chips) alongside 2 user-facing ports (1x USB-A 3.0 + 1x USB-C).

When connected via USB-A, only the USB 2.0 hub (2109:2820) is visible to the host; the USB 3.1 companion hub (2109:0820) requires USB-C. Listing 2109:2820 with 2 ports covers the common case and matches what most users will see.

Tested on Debian 13 and macOS 26, confirmed PPPS works on port 3 (USB-A).

---

Output of uhubctl:
```
Current status for hub 2-2 [2109:0820 VIA Labs, Inc. USB3.1 Hub, USB 3.10, 4 ports, ppps]
  Port 1: 02a0 power 5gbps Rx.Detect
  Port 2: 0203 power 5gbps U0 enable connect [0bda:8153 Realtek USB 10/100/1000 LAN 001000001]
  Port 3: 02a0 power 5gbps Rx.Detect
  Port 4: 02a0 power 5gbps Rx.Detect
Current status for hub 2-1 [2109:2820 VIA Labs, Inc. USB2.0 Hub, USB 2.10, 5 ports, ppps]
  Port 1: 0103 power enable connect [06c4:c412 Bizlink DELL DA300 MCU Ver0006]
  Port 2: 0100 power
  Port 3: 0100 power
  Port 4: 0100 power
  Port 5: 0100 power
```