### PR TITLE
Makefile: warn when pkg-config is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ ifneq (,$(shell which $(PKG_CONFIG)))
 	LDFLAGS += $(shell $(PKG_CONFIG) --libs libusb-1.0)
 else
 # But it should still build even if pkg-config is not available
+$(warning pkg-config not found; consider installing pkgconf.)
 	CFLAGS += -I/usr/include/libusb-1.0
 	LDFLAGS += -lusb-1.0
 endif


### PR DESCRIPTION
On macOS, the Makfile will fail if it can't find pkg-config, even if libusb is installed.
This patch checks for macOS and looks for the Homebrew-installed location of libusb,
but also will fall back to a sensible default location if Homebrew isn't installed.
