### PR TITLE
Add VID:PID for Rosonway RSH-ST10C-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This is list of known compatible USB hubs:
 | Rosonway           | RSH-A37S                                             | 7     | 3.0 |`2109:2822`| 2021    |      |
 | Rosonway           | RSH-A104 ([USB2 only](https://tinyurl.com/RSH-A104)) | 4     | 3.1 |`2109:2822`| 2022    |      |
 | Rosonway           | RSH-ST07C ([only 4](https://tinyurl.com/4pjnujrn))   | 7     | 3.0 |`2109:2822`| 2023    |      |
-| Rosonway           | RSH-ST10C-6 ([note](https://tinyurl.com/428vpa2f))   | 10    | 3.1 |           | 2024    |      |
+| Rosonway           | RSH-ST10C-6 ([note](https://tinyurl.com/428vpa2f))   | 10    | 3.1 |`0bda:0423`| 2024    |      |
 | Sanwa Supply       | USB-HUB14GPH                                         | 4     | 1.1 |           | 2001    | 2003 |
 | Satechi            | Mac Mini Hub (M1/M2)                                 | 4     | 3.0 |`2109:2817`| 2023    |      |
 | Seagate            | Backup Plus Hub STEL8000100                          | 2     | 3.0 |`0BC2:AB44`| 2016    |      |


### PR DESCRIPTION
Fills in the missing VID:PID for the Rosonway RSH-ST10C-6 entry.

Verified on macOS 15 (Apple Silicon) with an RSHTECH-branded RSH-ST10C-6: the root chip enumerates as `0bda:0423` (Realtek RTS5423; descriptor strings identify as "TerraMaster 4-Port USB 3.0 Hub"), with two cascaded `0bda:0411` (RTS5411) sub-hubs behind it.

Per-port VBUS switching re-confirmed by LED observation, including the caveats already documented in #616: the second USB-C port is always-on, and both the USB3 hub and its USB2 companion must be powered off to actually cut VBUS on a port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
